### PR TITLE
Making pyops python3.0 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ How to set downtime:
 Adding node for monitoring:
 
 First we need to edit examples/createhostExample.py file and a add node name from where pyops will fetch template data.
-For example, if you want to add a new nodes in devel environment, then we can take metadata from a devel node p5.pouta.csc.fi.
-If your newserver is p20.pouta.csc.fi, then we can do following.
+For example, if you want to add a new nodes in devel environment, then we can take metadata from a devel node
+reference-server.domain. If your newserver is new-server.domain, then we can do following.
 
     $ export prod_ops_user="username"
     $ read -s prod_ops_pass
     $ export prod_ops_pass
     $ export prod_ops_base="https://your-opsview-server/opsview/rest/""    
     $ vim examples/createhostExample.py
-data = opsprod.get_host_by_name("p5.pouta.csc.fi")
-newserver = { "ip": "p20.pouta.csc.fi", "name": "p20.pouta.csc.fi" }
+data = opsprod.get_host_by_name("reference-server.domain")
+newserver = { "ip": "new-server.domain", "name": "new-server.domain" }
 
-    $ python pyops/pyops.py examples/createhostExample.py
+    $ PYTHONPATH=./pyops python examples/createhostExample.py
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Usage
 
+How to set downtime:
+
     $ pip install pip install git+ssh://git@github.com/CSCfi/pyops.git
     $ pyops-downtime --help
     $ export prod_ops_user="username"
@@ -10,4 +12,19 @@ Usage
     $ export prod_ops_base="https://your-opsview-server/opsview/rest/""
     $ pyops-downtime -e +1d testserver1 testserver2
 
+Adding node for monitoring:
+
+First we need to edit examples/createhostExample.py file and a add node name from where pyops will fetch template data.
+For example, if you want to add a new nodes in devel environment, then we can take metadata from a devel node p5.pouta.csc.fi.
+If your newserver is p20.pouta.csc.fi, then we can do following.
+
+    $ export prod_ops_user="username"
+    $ read -s prod_ops_pass
+    $ export prod_ops_pass
+    $ export prod_ops_base="https://your-opsview-server/opsview/rest/""    
+    $ vim examples/createhostExample.py
+data = opsprod.get_host_by_name("p5.pouta.csc.fi")
+newserver = { "ip": "p20.pouta.csc.fi", "name": "p20.pouta.csc.fi" }
+
+    $ python pyops/pyops.py examples/createhostExample.py
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ How to set downtime:
 Adding node for monitoring:
 
 First we need to edit examples/createhostExample.py file and a add node name from where pyops will fetch template data.
-For example, if you want to add a new nodes in devel environment, then we can take metadata from a devel node
+For example, if you want to add a new node in devel environment, then we can take metadata from a devel node
 reference-server.domain. If your newserver is new-server.domain, then we can do following.
 
     $ export prod_ops_user="username"

--- a/examples/createhostExample.py
+++ b/examples/createhostExample.py
@@ -26,15 +26,15 @@ opsprod = pyops.opsview(prod_user,prod_pass,prod_base)
 data = opsprod.get_host_by_name("name_of_the_server")
 
 # Print the data for the host
-print (opsprod.json_nice(data))
+print(opsprod.json_nice(data))
 
 # Get the ID of the hosts (this is what you use as a source for the copy)
 hostid = data["object"]["id"]
-print (hostid)
+print(hostid)
 
 # You can also get the host data by id
 data = opsprod.get_hostconfig(hostid)
-print (opsprod.json_nice(data))
+print(opsprod.json_nice(data))
 
 # Let's add a new server. We only define IP and name, the rest is copied from the
 # original server
@@ -46,4 +46,4 @@ newserver = { "ip": "newhostname_or_ip", "name": "newhostname" }
 # the new host. 
 
 response = opsprod.post_data(newserver,"config/host/" + hostid)
-print (response)
+print(response)

--- a/examples/createhostExample.py
+++ b/examples/createhostExample.py
@@ -26,15 +26,15 @@ opsprod = pyops.opsview(prod_user,prod_pass,prod_base)
 data = opsprod.get_host_by_name("name_of_the_server")
 
 # Print the data for the host
-print opsprod.json_nice(data)
+print (opsprod.json_nice(data))
 
 # Get the ID of the hosts (this is what you use as a source for the copy)
 hostid = data["object"]["id"]
-print hostid
+print (hostid)
 
 # You can also get the host data by id
 data = opsprod.get_hostconfig(hostid)
-print opsprod.json_nice(data)
+print (opsprod.json_nice(data))
 
 # Let's add a new server. We only define IP and name, the rest is copied from the
 # original server
@@ -46,4 +46,4 @@ newserver = { "ip": "newhostname_or_ip", "name": "newhostname" }
 # the new host. 
 
 response = opsprod.post_data(newserver,"config/host/" + hostid)
-print response
+print (response)

--- a/examples/enable_host_flapping_detection.py
+++ b/examples/enable_host_flapping_detection.py
@@ -40,34 +40,34 @@ for host in data1['object']['hosts']:
 for host in data2['object']['hosts']:
   hosts.append(host['name'])
 
-print hosts
+print (hosts)
 
 # Remove this when you have the bottom figured out
 exit(0)
 
 for host in hosts:
-  print "Attempting to modify host " + host
+  print ("Attempting to modify host " + host)
   data = opsprod.get_host_by_name(host)
   hostid = data["object"]["id"]
   cnt = 0
 
   if data["object"]["notification_interval"] == "60":
-    print data["object"]["notification_interval"]
-    print "would set notification_interval from 60 to 0"
+    print (data["object"]["notification_interval"])
+    print ("would set notification_interval from 60 to 0")
     data["object"]["notification_interval"] = "0"
     cnt = cnt + 1
 
   if data["object"]["flap_detection_enabled"] == "0":
-    print data["object"]["flap_detection_enabled"]
-    print "would enable flap detection"
+    print (data["object"]["flap_detection_enabled"])
+    print ("would enable flap detection")
     data["object"]["flap_detection_enabled"] = "1"
     cnt = cnt + 1
 
   if cnt != 0:
-    print "Sending new config to opsview"
+    print ("Sending new config to opsview")
     res = opsprod.put_data(data, 'config/host/' + hostid);
   else:
-    print "Not changing anything"
+    print ("Not changing anything")
 
 if cnt != 0:
-  print "Reload opsview"
+  print ("Reload opsview")

--- a/examples/enable_host_flapping_detection.py
+++ b/examples/enable_host_flapping_detection.py
@@ -29,7 +29,7 @@ data1 = opsprod.get_hostgroup(222222222)
 data2 = opsprod.get_hostgroup(333333333)
 
 # Print the data for the host
-#print opsprod.json_nice(data0)
+#print(opsprod.json_nice(data0))
 
 hosts = []
 
@@ -40,34 +40,34 @@ for host in data1['object']['hosts']:
 for host in data2['object']['hosts']:
   hosts.append(host['name'])
 
-print (hosts)
+print(hosts)
 
 # Remove this when you have the bottom figured out
 exit(0)
 
 for host in hosts:
-  print ("Attempting to modify host " + host)
+  print("Attempting to modify host " + host)
   data = opsprod.get_host_by_name(host)
   hostid = data["object"]["id"]
   cnt = 0
 
   if data["object"]["notification_interval"] == "60":
-    print (data["object"]["notification_interval"])
-    print ("would set notification_interval from 60 to 0")
+    print(data["object"]["notification_interval"])
+    print("would set notification_interval from 60 to 0")
     data["object"]["notification_interval"] = "0"
     cnt = cnt + 1
 
   if data["object"]["flap_detection_enabled"] == "0":
-    print (data["object"]["flap_detection_enabled"])
-    print ("would enable flap detection")
+    print(data["object"]["flap_detection_enabled"])
+    print("would enable flap detection")
     data["object"]["flap_detection_enabled"] = "1"
     cnt = cnt + 1
 
   if cnt != 0:
-    print ("Sending new config to opsview")
+    print("Sending new config to opsview")
     res = opsprod.put_data(data, 'config/host/' + hostid);
   else:
-    print ("Not changing anything")
+    print("Not changing anything")
 
 if cnt != 0:
-  print ("Reload opsview")
+  print("Reload opsview")

--- a/examples/host_data_add.py
+++ b/examples/host_data_add.py
@@ -24,13 +24,13 @@ opsprod = pyops.opsview(prod_user,prod_pass,prod_base)
 data = opsprod.get_host_by_name(hosts[0])
 
 # Print the data for the host
-print opsprod.json_nice(data)
+print (opsprod.json_nice(data))
 
 # Remove this when you have the bottom figured out
 exit(0)
 
 for host in hosts:
-  print "Modifying host " + host
+  print ("Modifying host " + host)
   data = opsprod.get_host_by_name(host)
   hostid = data["object"]["id"]
 

--- a/examples/host_data_add.py
+++ b/examples/host_data_add.py
@@ -24,13 +24,13 @@ opsprod = pyops.opsview(prod_user,prod_pass,prod_base)
 data = opsprod.get_host_by_name(hosts[0])
 
 # Print the data for the host
-print (opsprod.json_nice(data))
+print(opsprod.json_nice(data))
 
 # Remove this when you have the bottom figured out
 exit(0)
 
 for host in hosts:
-  print ("Modifying host " + host)
+  print("Modifying host " + host)
   data = opsprod.get_host_by_name(host)
   hostid = data["object"]["id"]
 


### PR DESCRIPTION
Python has 2.7 outdated, which makes us update all python code compatible to version 3.0.

CCCP-3150