### PR TITLE
Fix running as script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,57 @@
 # pyops - Python bindings for the Opsview API
 
-Usage
+## Installation
 
-How to set downtime:
+```sh
+pip install git+ssh://git@github.com/CSCfi/pyops.git
+```
 
-    $ pip install git+ssh://git@github.com/CSCfi/pyops.git
-    $ pyops-downtime --help
-    $ export prod_ops_user="username"
-    $ read -s prod_ops_pass
-    $ export prod_ops_pass
-    $ export prod_ops_base="https://your-opsview-server/opsview/rest/""
-    $ pyops-downtime -e +1d testserver1 testserver2
+## Usage
 
-Adding node for monitoring:
+See command help with `pyops-downtime --help`.
+PyOPS expects to find the following variables:
 
-First we need to edit examples/createhostExample.py file and a add node name from where pyops will fetch template data.
-For example, if you want to add a new node in devel environment, then we can take metadata from a devel node
-reference-server.domain. If your newserver is new-server.domain, then we can do following.
+- `prod_ops_base` -- The REST API endpoint of your OpsView-instance
+- `prod_ops_user` -- username to be used to login to opsview
+- `prod_ops_pass` -- password for the user
 
-    $ export prod_ops_user="username"
-    $ read -s prod_ops_pass
-    $ export prod_ops_pass
-    $ export prod_ops_base="https://your-opsview-server/opsview/rest/""
-    $ vim examples/createhostExample.py
-data = opsprod.get_host_by_name("reference-server.domain")
-newserver = { "ip": "new-server.domain", "name": "new-server.domain" }
+Can be setup with following:
 
-    $ PYTHONPATH=./pyops python examples/createhostExample.py
+```sh
+export prod_ops_base="https://<your-opsview-server>/rest/"
+export prod_ops_user="$USER"
+read -s prod_ops_pass && export prod_ops_pass # Read OpsView password from stdin
+```
 
+Optional arguments:
+
+```none
+-e ENDTIME, --endtime ENDTIME
+            Downtime end time in an opsview format (e.g. +10m, +2d or '2018-08-10 15:00').
+-d, --delete          Delete downtimes instead of adding them.
+-c COMMENT, --comment COMMENT
+                    Comment for the downtime
+-s STARTTIME, --starttime STARTTIME
+                    Start time in an opsview format ('2018-08-10 13:00'). Defaults to 'now'
+-g, --group     Interpret the host list as a list of hostgroup names,
+                    and apply the downtime to all the hosts in the groups.
+```
+
+### Setting/Deleting a downtime for node(s)
+
+```sh
+# Individual nodes
+pyops-downtime -e +1d -c "Server maintenance" testserver1 testserver2
+## Delete
+pyops-downtime -d testserver1 testserver2
+
+# A named group of nodes
+pyops-downtime -e +2h -c "Server maintenance" -g "My Monitoring Group"
+pyops-downtime -d -g "My Monitoring Group"
+```
+
+### Other Examples
+
+Example scripts for inspiration can be found from `./examples/`.
+
+> Copy and edit as needed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Usage
 
 How to set downtime:
 
-    $ pip install pip install git+ssh://git@github.com/CSCfi/pyops.git
+    $ pip install git+ssh://git@github.com/CSCfi/pyops.git
     $ pyops-downtime --help
     $ export prod_ops_user="username"
     $ read -s prod_ops_pass
@@ -21,7 +21,7 @@ reference-server.domain. If your newserver is new-server.domain, then we can do 
     $ export prod_ops_user="username"
     $ read -s prod_ops_pass
     $ export prod_ops_pass
-    $ export prod_ops_base="https://your-opsview-server/opsview/rest/""    
+    $ export prod_ops_base="https://your-opsview-server/opsview/rest/""
     $ vim examples/createhostExample.py
 data = opsprod.get_host_by_name("reference-server.domain")
 newserver = { "ip": "new-server.domain", "name": "new-server.domain" }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PyOPS expects to find the following variables:
 Can be setup with following:
 
 ```sh
-export prod_ops_base="https://<your-opsview-server>/rest/"
+export prod_ops_base="https://<your-opsview-server>/opsview/rest/"
 export prod_ops_user="$USER"
 read -s prod_ops_pass && export prod_ops_pass # Read OpsView password from stdin
 ```

--- a/pyops/pyops.py
+++ b/pyops/pyops.py
@@ -35,7 +35,7 @@ class LoginFailedException(PyOpsException):
 
 ##### CLASS STARTED:
 
-class opsview:
+class Opsview:
     def __init__(self, ops_user, ops_pass, ops_base):
         self.log = logging.getLogger(__name__)
         self.log.setLevel(logging.WARNING)
@@ -95,7 +95,7 @@ class opsview:
         Log into Opsview and get a Token
         '''
         login = {'username': self.ops_user,
-                 'password': self.ops_pass}
+                'password': self.ops_pass}
         try:
             response = requests.post(self.ops_base + "login", login, verify=False)
             token = response.json()['token']
@@ -168,8 +168,8 @@ class opsview:
 
         This is the same as reloading the config in the GUI and is needed before changes take effect.
         This does the following:
-         - Dumps the Opsview database into nagios config files (ugly ones!)
-         - Restarts the nagios server
+        - Dumps the Opsview database into nagios config files (ugly ones!)
+        - Restarts the nagios server
 
         This is propper scary because we might restart while someone else is making changes. Opsview's
         design is the issue here. Probably best to make changes with the api and manually restart.
@@ -222,10 +222,10 @@ class opsview:
         ##
         # Set a downtime for hg_id from starttime to endtime with comment
         ## Lessons learnt while writing this:
-         - API user needs to have DOWNTIMEALL permissions
-         - send the data with json.loads like: post_data(json.loads('{ "json": "json" }')), otherwise you get an error like this:
-            JSON text must be an object or array (but found number, string, true, false or null, use allow_nonref to allow this) at (eval 1868) line 161, <\$fh> line 1.
-         - error "no object chosen" in opsview-web.log probably means the URL doesn't have a valid host= or hostgroupid= parameter, it should be like these (without starttimes etc):
+            - API user needs to have DOWNTIMEALL permissions
+            - send the data with json.loads like: post_data(json.loads('{ "json": "json" }')), otherwise you get an error like this:
+                JSON text must be an object or array (but found number, string, true, false or null, use allow_nonref to allow this) at (eval 1868) line 161, <\$fh> line 1.
+            - error "no object chosen" in opsview-web.log probably means the URL doesn't have a valid host= or hostgroupid= parameter, it should be like these (without starttimes etc):
         /opsview/rest/downtime?host=my-test-server
         /opsview/rest/downtime?hostgroupid=103
         ######
@@ -236,7 +236,7 @@ class opsview:
         # endtime can also be like this:
         endtime="+9h"
         comment="$0 api call"
-        # 
+        #
 
         # TODO: Delete downtimes.
         # This needs a new function which can do http DELETE, see url above for curl example.
@@ -254,7 +254,7 @@ class opsview:
         '''
 
         for host in hosts:
-            try: 
+            try:
                 self.post_data(json.loads('{ "starttime" : "%s", "endtime" : "%s", "comment" : "%s" }  ' % (starttime, endtime, comment)),"downtime?hst.hostname=%s" % host)
                 self.log.debug("Downtime set for %s" % host)
             except requests.exceptions.HTTPError:
@@ -351,8 +351,8 @@ class opsview:
         so we'll just build the string ourselves '''
         self.log.info("Search" + item_type + ' for ' + search_string)
         return self.get_data('config/' + item_type +
-                                                 '?rows=all&json_filter={"name":{"-like":"%25' +
-                                                 search_string + '%25"}}')
+                                                '?rows=all&json_filter={"name":{"-like":"%25' +
+                                                search_string + '%25"}}')
 
     def search_hosttemplate(self, search_string):
         '''
@@ -393,22 +393,22 @@ class opsview:
 
         ''' get_host_by_name() returns False if there is no match '''
         if host:
-         host_attrs = host['object']['hostattributes']
-         for attr in host_attrs:
-             ''' If the attribute is already set once, remove it!
-             Not all attributes work this way! DISK for example '''
-             if attr['name'] == name:
-                 host_attrs.remove(attr)
-         ''' Append the new attribute '''
-         host_attrs.append(new_attr)
+            host_attrs = host['object']['hostattributes']
+            for attr in host_attrs:
+                ''' If the attribute is already set once, remove it!
+                Not all attributes work this way! DISK for example '''
+                if attr['name'] == name:
+                    host_attrs.remove(attr)
+            ''' Append the new attribute '''
+            host_attrs.append(new_attr)
 
-         ''' Add the attributes back to the object.
-         (assuming we are working on a copy of the array) '''
-         host['object']['hostattributes'] = host_attrs
-         self.update_host(host)
-         return True
+            ''' Add the attributes back to the object.
+            (assuming we are working on a copy of the array) '''
+            host['object']['hostattributes'] = host_attrs
+            self.update_host(host)
+            return True
         else:
-         return False
+            return False
 
     def set_hostgroup_attribute(self, hostgroup_name, name, value):
         hostgroup = self.get_hostgroup_by_name(hostgroup_name)

--- a/pyops/set_downtime.py
+++ b/pyops/set_downtime.py
@@ -4,8 +4,8 @@
 #
 import os
 import sys
-import pyops
 import argparse
+from pyops import pyops
 
 #Configure Variables
 # To use this, set prod_base to the rest url of the opsview server.
@@ -18,16 +18,16 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv
 
-    parser = argparse.ArgumentParser(description='Set downtime for hosts in opsview.', 
-                                     formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     epilog=("Examples:\n"
-                                             "./set_downtime.py -e +1d testserver1 testserver2\n"
-                                             "./set_downtime.py -s '2018-08-10 08:00' -c "
-                                             "'Server upgrade and maintenance' -e +8h prodserver1\n"
+    parser = argparse.ArgumentParser(description='Set downtime for hosts in opsview.',
+                                    formatter_class=argparse.RawDescriptionHelpFormatter,
+                                    epilog=("Examples:\n"
+                                            "./set_downtime.py -e +1d testserver1 testserver2\n"
+                                            "./set_downtime.py -s '2018-08-10 08:00' -c "
+                                            "'Server upgrade and maintenance' -e +8h prodserver1\n"
                                             "./set_downtime.py -d testserver1 testserver2 prodserver1\n"
                                             "./set_downtime.py -g -e +1d 'compute node group with spaces'"
-                                             "'compute node group 2'")
-                                     )
+                                            "'compute node group 2'")
+                                    )
 
     parser.add_argument('hosts', nargs='*', help="A space separated list of hosts (or hostgroups, see -g) to apply the downtime to.")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -57,8 +57,8 @@ def main(argv=None):
         print('Error: Specify one or more hosts/hostgroups')
         return 1
 
-    opsprod = pyops.opsview(prod_user, prod_pass, prod_base)
- 
+    opsprod = pyops.Opsview(prod_user, prod_pass, prod_base)
+
     if args.group:
         hostlist = []
         for host in args.hosts:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1',
+    version='0.0.2',
 
     description='PyOPS ',
     long_description=long_description,
@@ -62,7 +62,9 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.9',
+
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
## Proposed changes

The current master produces non-callable script that ends up failing with module import error.
This PR fixes import errors imports. 
This PR fixes the AttributeError.

Against a best practice I also added some general improvements to the Readme in this same PR. 

### How to reproduce 

- python --version == 3.x
- install and run with `pip install git+ssh://git@github.com/CSCfi/pyops.git`
- try to set downtime `pyops-downtime -e +10m myserver`

Output:

```
Traceback (most recent call last):
 [...]
  File "<path-to-python3.9>/site-packages/pyops/set_downtime.py", line 60, in main
    opsprod = pyops.opsview(prod_user, prod_pass, prod_base)
AttributeError: module 'pyops' has no attribute 'opsview'
```

## Types of changes

What types of changes does your code introduce to PyOPS?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Further comments

The packaging can be modified to allow base import of the pyops-module aka. `import pyops` (instead of the current workaround `import pyops from pyops`).
I am not an expert on python packaging so I leave this as a TODO.

The fixes are untested on Python 2, as it is already EOL.
